### PR TITLE
No need for class attributes.

### DIFF
--- a/DictionaryEntry.py
+++ b/DictionaryEntry.py
@@ -1,18 +1,14 @@
 import re
 
 class DictionaryEntry:
-    __word = ''
-    __type = ''
-    __def = ''
-    __tran = ''
 
-    patternStrFromDict = re.compile("(.*):(.*):(.*):(.*);")
+    __patternStrFromDict = re.compile("(.*):(.*):(.*):(.*);")
     def __init__(self, strFromDict = ''):
         if strFromDict == '':
             return
 
         (self.__word, self.__type, self.__def, self.__tran) = \
-                      self.patternStrFromDict.search(strFromDict).groups()
+                      DictionaryEntry.__patternStrFromDict.search(strFromDict).groups()
 
         self.__word = self.__word.strip()
         self.__type = self.__type.strip()


### PR DESCRIPTION
You use class and object attributes with the same names (__word, __type, __def, __tran). But in fact, these class attributes are not used and not needed.

If I understand correctly, you want to do C++ - style (where in the class we must declare all the attributes, but in Python there is no such need).